### PR TITLE
refactor: revise JwtAuthenticationFilter logic, add tests

### DIFF
--- a/src/test/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,118 @@
+package com.nivlalulu.nnpro.security;
+
+import com.nivlalulu.nnpro.service.IJwtTokenService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    UserDetailsService userDetailsService;
+    @Mock
+    private IJwtTokenService jwtTokenService;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockFilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        filterChain = new MockFilterChain();
+        SecurityContextHolder.clearContext(); // otherwise the context is shared between tests
+    }
+
+
+    @Test
+    void noTokenPublicApi_ShouldProceed() throws ServletException, IOException {
+        setupRequest("/public/endpoint", null);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void noTokenSecuredApi_ShouldRespondUnauthorized() throws ServletException, IOException {
+        setupRequest("/some-secured/endpoint", null);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void validTokenSecuredApi_ShouldSetSecurityContext() throws ServletException, IOException {
+        String token = "some_valid_token";
+        String username = "user";
+        boolean isValid = true;
+        setupRequest("/some-secured/endpoint", token);
+        mockToken(token, username, isValid);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        assertEquals(username, authentication.getName());
+        assertTrue(authentication.isAuthenticated());
+    }
+
+    @Test
+    void invalidTokenSecuredApi_ShouldRespondUnauthorized() throws ServletException, IOException {
+        String token = "some_invalid_token";
+        String username = "user";
+        boolean isValid = false;
+        setupRequest("/some-secured/endpoint", token);
+        mockToken(token, username, isValid);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    private void setupRequest(String uri, String token) {
+        request.setRequestURI(uri);
+        if (token != null) {
+            request.addHeader("Authorization", "Bearer " + token);
+        }
+    }
+
+    private void mockToken(String token, String username, boolean isValid) {
+        UserDetails userDetails = new User(username, "password", List.of(new SimpleGrantedAuthority("test_role")));
+        when(jwtTokenProvider.extractUsername(token, JwtTokenType.ACCESS))
+                .thenReturn(username);
+        when(userDetailsService.loadUserByUsername(username))
+                .thenReturn(userDetails);
+        when(jwtTokenProvider.isTokenValid(token, JwtTokenType.ACCESS, userDetails))
+                .thenReturn(isValid);
+    }
+}


### PR DESCRIPTION
Improvements to security and error handling:

* [`src/main/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilter.java`](diffhunk://#diff-4d375e0d631fbb9524229031a4cf5cdeafba28be7caa7929e8ff1092087ef660R15-R22): Added `UsernameNotFoundException` and `Optional` imports to handle user details fetching more robustly.
* [`src/main/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilter.java`](diffhunk://#diff-4d375e0d631fbb9524229031a4cf5cdeafba28be7caa7929e8ff1092087ef660L50-R72): Replaced the call to `filterChain.doFilter` with `denyRequestInvalidToken` when the access token is missing or invalid, ensuring that invalid requests are properly denied.
* [`src/main/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilter.java`](diffhunk://#diff-4d375e0d631fbb9524229031a4cf5cdeafba28be7caa7929e8ff1092087ef660L88-R98): Renamed `setInvalidTokenResponse` to `denyRequestInvalidToken` for clarity.
* [`src/main/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilter.java`](diffhunk://#diff-4d375e0d631fbb9524229031a4cf5cdeafba28be7caa7929e8ff1092087ef660L117-R141): Refactored `setSecurityContext` method to `fetchDetailsIfAccessTokenValid` and updated its logic to use `Optional` for better error handling and readability.

Addition of unit tests:

* [`src/test/java/com/nivlalulu/nnpro/security/JwtAuthenticationFilterTest.java`](diffhunk://#diff-11af774ed3caeba80de790e0fe1341d4a93d5cbb6be0d30b48d92e1a137e0e56R1-R118): Added a comprehensive test suite for `JwtAuthenticationFilter`, including tests for scenarios with no token, valid token, and invalid token.