### PR TITLE
feat: Add reset token rate limiting

### DIFF
--- a/src/main/java/com/nivlalulu/nnpro/common/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/nivlalulu/nnpro/common/controller/GlobalControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 import java.util.Map;
@@ -100,6 +101,13 @@ public class GlobalControllerAdvice {
     public ResponseEntity<?> handleAccessDeniedException(AccessDeniedException e) {
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
+                .body(e.getMessage());
+    }
+
+    @ExceptionHandler(TooManyRequestsException.class)
+    public ResponseEntity<?> handleTooManyRequestsException(TooManyRequestsException e) {
+        return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
                 .body(e.getMessage());
     }
 }

--- a/src/main/java/com/nivlalulu/nnpro/common/exceptions/TooManyRequestsException.java
+++ b/src/main/java/com/nivlalulu/nnpro/common/exceptions/TooManyRequestsException.java
@@ -1,0 +1,7 @@
+package com.nivlalulu.nnpro.common.exceptions;
+
+public class TooManyRequestsException extends RuntimeException {
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nivlalulu/nnpro/configuration/CacheConfiguration.java
+++ b/src/main/java/com/nivlalulu/nnpro/configuration/CacheConfiguration.java
@@ -6,10 +6,22 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration(proxyBeanMethods = false)
 @EnableCaching
 public class CacheConfiguration {
+    @Bean
+    public RedisTemplate<String, Integer> redisIntegerTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+        return redisTemplate;
+    }
     @Bean
     public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
         return builder -> builder

--- a/src/main/java/com/nivlalulu/nnpro/model/PasswordResetToken.java
+++ b/src/main/java/com/nivlalulu/nnpro/model/PasswordResetToken.java
@@ -26,7 +26,7 @@ public class PasswordResetToken {
     @Column(name = "expiry_date", nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private Instant expiryDate;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/nivlalulu/nnpro/security/service/IRateLimiter.java
+++ b/src/main/java/com/nivlalulu/nnpro/security/service/IRateLimiter.java
@@ -1,0 +1,15 @@
+package com.nivlalulu.nnpro.security.service;
+
+import java.time.Duration;
+
+public interface IRateLimiter {
+
+   /**
+   * Check if the request is allowed
+   * @param key
+   * @param limit
+   * @param window
+   * @return
+   */
+   boolean isAllowed(String key, int limit, Duration window);
+}

--- a/src/main/java/com/nivlalulu/nnpro/security/service/impl/RedisRateLimiter.java
+++ b/src/main/java/com/nivlalulu/nnpro/security/service/impl/RedisRateLimiter.java
@@ -1,0 +1,33 @@
+package com.nivlalulu.nnpro.security.service.impl;
+
+import com.nivlalulu.nnpro.security.service.IRateLimiter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+//todo: Could use Bucket4j instead of misusing our cache
+@Service
+@RequiredArgsConstructor
+public class RedisRateLimiter implements IRateLimiter {
+    private final RedisTemplate<String, Integer> redisTemplate;
+
+    @Override
+    public boolean isAllowed(String key, int limit, Duration window) {
+        String redisKey = "rate_limit:" + key;
+        Integer currentCount = redisTemplate.opsForValue().get(redisKey);
+
+        if (currentCount == null) {
+            redisTemplate.opsForValue().set(redisKey, 1, window);
+            return true;
+        }
+
+        if (currentCount >= limit) {
+            return false; // Rate limit exceeded
+        }
+
+        redisTemplate.opsForValue().increment(redisKey);
+        return true;
+    }
+}

--- a/src/main/java/com/nivlalulu/nnpro/service/impl/UserCredentialsService.java
+++ b/src/main/java/com/nivlalulu/nnpro/service/impl/UserCredentialsService.java
@@ -31,11 +31,13 @@ public class UserCredentialsService implements IUserCredentialsService {
 
     @Override
     @Transactional
-    // Existing token is implicitly invalidated as we can't resend it anyway and have a OneToOne relationship
     public void createAndSendPasswordResetToken(String username) {
         var now = Instant.now();
         var user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException("User", "username", username));
+        passwordResetTokenRepository
+                .findByUser(user)
+                .ifPresent(passwordResetTokenRepository::delete);
         TokenData generated = generateToken(now);
         var token = new PasswordResetToken(generated.hash, generated.expiration, user);
         log.debug("Generated token '{}' for user '{}', email '{}'.",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -48,8 +48,8 @@ mail:
   host: smtp.gmail.com
   port: 587
   debug: true
-  username: CHANGE_ME
-  password: CHANGE_ME
+  username: #CHANGE_ME
+  password: #CHANGE_ME
   properties:
     mail:
       smtp:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,8 +16,8 @@ mail:
   host: smtp.gmail.com
   port: 587
   debug: true
-  username: CHANGE_ME
-  password: CHANGE_ME
+  username: #CHANGE_ME
+  password: #CHANGE_ME
   properties:
     mail:
       smtp:


### PR DESCRIPTION
### Rate Limiting:
* Added a new `IRateLimiter` interface and its implementation `RedisRateLimiter` to manage rate limiting using Redis. [[1]](diffhunk://#diff-b1cee13dad218888c98de12cfb49911b0e1797cca570d082bcb8f657234e7ffbR1-R15) [[2]](diffhunk://#diff-3f7661a0c6898ff108e79e624830d3c91b90761cb8e7e5a289c056f9fc58d1a7R1-R33)
* Updated `UserCredentialsService` to enforce rate limiting on password reset requests, throwing a `TooManyRequestsException` if the limit is exceeded. [[1]](diffhunk://#diff-755ca78a808baf433efd52802da6e795d4c578d38bcf40e121180624cc0c8893R21) [[2]](diffhunk://#diff-755ca78a808baf433efd52802da6e795d4c578d38bcf40e121180624cc0c8893R35-R70)

### Exception Handling Improvements:
* Introduced a new `TooManyRequestsException` class to handle scenarios where rate limits are exceeded.
* Added an exception handler for `TooManyRequestsException` in `GlobalControllerAdvice`.

### Cache Configuration Updates:
* Enhanced `CacheConfiguration` to include a new `RedisTemplate` bean for handling integer values.

### Miscellaneous Changes:
* Updated `PasswordResetToken` entity to include `orphanRemoval` and `cascade` options for the `user` field.
* Commented out placeholder values for email configuration in `application-dev.yml`.