### PR TITLE
fix: redis testcontainer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,4 +98,12 @@ tasks.named('test') {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
 	systemProperty 'spring.profiles.active', 'test'
+
+	testLogging {
+		events "passed", "skipped", "failed"
+		showExceptions true
+		showCauses true
+		showStackTraces true
+		showStandardStreams true
+	}
 }

--- a/src/test/java/com/nivlalulu/nnpro/service/impl/UserCredentialsIntegrationTest.java
+++ b/src/test/java/com/nivlalulu/nnpro/service/impl/UserCredentialsIntegrationTest.java
@@ -61,8 +61,8 @@ public class UserCredentialsIntegrationTest {
         registry.add("spring.datasource.password", postgres::getPassword);
 
         // Redis properties
-        registry.add("spring.redis.host", redis::getHost);
-        registry.add("spring.redis.port", redis::getFirstMappedPort);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
     }
 
     @BeforeEach

--- a/src/test/java/com/nivlalulu/nnpro/service/impl/UserCredentialsIntegrationTest.java
+++ b/src/test/java/com/nivlalulu/nnpro/service/impl/UserCredentialsIntegrationTest.java
@@ -62,7 +62,7 @@ public class UserCredentialsIntegrationTest {
 
         // Redis properties
         registry.add("spring.redis.host", redis::getHost);
-        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+        registry.add("spring.redis.port", redis::getFirstMappedPort);
     }
 
     @BeforeEach


### PR DESCRIPTION
This pull request includes a small change to the `UserCredentialsIntegrationTest.java` file. The change updates the Redis host property to use the container IP address instead of the host.

* [`src/test/java/com/nivlalulu/nnpro/service/impl/UserCredentialsIntegrationTest.java`](diffhunk://#diff-db6fc5e27c446ad0e66e1e77a8547ab15982c8e1ab03129102d02e8c544e80d5L64-R64): Updated the Redis host property to use `redis::getContainerIpAddress` instead of `redis::getHost`.